### PR TITLE
fix:未ログインユーザーが投稿のない投稿一覧ページを閲覧したときに起こるエラー解消

### DIFF
--- a/app/views/public/itineraries/_index.html.erb
+++ b/app/views/public/itineraries/_index.html.erb
@@ -56,19 +56,13 @@
     <% end %>
   <!-- しおりがない場合 -->
   <% else %>
-    <% if current_user.itineraries.empty? %>
-      <div class ="my-3">
-        <h6>登録されているしおりがまだありません！</h6>
-        <h6>新規投稿してみませんか？</h6>
-        <%= link_to new_itinerary_path,class: "btn btn-hover btn-submit my-4" do %>
-          しおり作成
-        <% end %>
-      </div>
-    <% else %>
-      <div class ="my-3">
-        <h6>登録されているしおりがまだありません！</h6>
-      </div>
-    <% end %>
+    <div class ="my-3">
+      <h6>登録されているしおりがまだありません！</h6>
+      <h6>新規投稿してみませんか？</h6>
+      <%= link_to new_itinerary_path,class: "btn btn-hover btn-submit my-4" do %>
+        しおり作成
+      <% end %>
+    </div>
   <% end %>
 </div>
     


### PR DESCRIPTION
itinerary _indexファイルのcurrent_userのif文を削除。
未ログインユーザーが、投稿がまだ何もされていない投稿一覧ページを見たときにエラーが起きていた現象を解消。