### PR TITLE
fix:itinerary showページ　住所登録のない場合に、東京駅を表示できるようにコード修正、不要なコントローラーのコード削除

### DIFF
--- a/app/controllers/public/itineraries_controller.rb
+++ b/app/controllers/public/itineraries_controller.rb
@@ -54,23 +54,11 @@ class Public::ItinerariesController < ApplicationController
     @latest_updated_at = @itinerary.latest_updated_at
 
     # destinationsの中から最も早い日付と時間のデータを取得
-    if @itinerary.destinations.exists?
-        @destinations_with_address = @itinerary.destinations.where.not(address: [nil, ''])
-        @earliest = @itinerary.destinations
-        .where(day_number: @itinerary.destinations.minimum(:day_number))
-        .order(:start_time)
-        .first
-    else 
-      @earliest = OpenStruct.new(
-        id: nil, 
-        name: "デフォルトの場所", 
-        day_number: 1, 
-        start_time: "2024-01-01 00:00:00", 
-        address: "東京", 
-        latitude: 35.681236,  # 東京駅の緯度
-        longitude: 139.767125 # 東京駅の経度
-      )
-    end
+      @map_destinations = @itinerary.destinations
+      @earliest = @itinerary.destinations
+      .where(day_number: @itinerary.destinations.minimum(:day_number))
+      .order(:start_time)
+      .first
 
     #byebug
     #map表示に渡す引数

--- a/app/javascript/packs/map.js
+++ b/app/javascript/packs/map.js
@@ -7,6 +7,7 @@
 // ライブラリの読み込み
 let map;
 
+
 async function initMap() {
   const { Map } = await google.maps.importLibrary("maps");
   const {AdvancedMarkerElement} = await google.maps.importLibrary("marker");
@@ -20,7 +21,8 @@ async function initMap() {
     return;                                                         // itineraryId が取得できなければ終了
   }
 
-
+  const tokyoLatitude = 35.681236;
+  const tokyoLongitude = 139.767125;
 
   //tryが処理できなかったらerror処理へ
   try {
@@ -36,10 +38,12 @@ async function initMap() {
 
     // 地図の中心を設定
     //const center = { lat: earliest.latitude, lng: earliest.longitude };
-    const center = (earliest && typeof earliest.latitude === 'number' && typeof earliest.longitude === 'number')
+    const center = earliest
     ? { lat: earliest.latitude, lng: earliest.longitude }
-    : { lat: 35.681236, lng: 139.767125 };  // 東京駅のデフォルト座標
-    console.log("Map center:", center);                                    // デバッグ用
+    : { lat: tokyoLatitude, lng: tokyoLongitude };  // 東京駅のデフォルト座標
+    console.log("Map center:", center);     
+                                   // デバッグ用
+
 
     // 地図を初期化
     map = new Map(document.getElementById("map"), {
@@ -49,9 +53,12 @@ async function initMap() {
       mapTypeControl: false
     });
     console.log(data)
+    console.log('--------')
+    console.log(items)
+    console.log('--------')
     items.forEach( item => {
       console.log(item)
-      const { latitude, longitude, name , start_time ,day_number, destination_image, image } = item;
+      const { latitude, longitude, name, start_time ,day_number, destination_image, image, address } = item;
 
       console.log("Marker data:", { latitude, longitude, name ,start_time, day_number,destination_image, image });                // デバッグ用
 
@@ -60,12 +67,10 @@ async function initMap() {
         hour: 'numeric',
         minute: 'numeric',
         hour12: false, // 24時間表記
-      });
-
-
+      })
 
       const marker = new google.maps.marker.AdvancedMarkerElement ({
-        position: { lat: latitude, lng: longitude },
+        position: { lat: address ? latitude : tokyoLatitude, lng: address ? longitude : tokyoLongitude },
         map,
         title: name,
         // 他の任意のオプションもここに追加可能
@@ -78,6 +83,7 @@ async function initMap() {
         <p class="lead m-0">${day_number}日目</p>
         <p class="lead m-0">${formattedStartTime}～</p>
         <p class="lead m-0">${name}</p>
+        <p class="lead m-0">${address ? address : "住所登録はありません"}</p>
       </div>
     `;
     

--- a/app/views/public/itineraries/show.json.jbuilder
+++ b/app/views/public/itineraries/show.json.jbuilder
@@ -15,7 +15,7 @@ json.data do
   end
 
   json.items do
-    json.array!(@destinations_with_address) do |destination|
+    json.array!(@map_destinations) do |destination|
       json.id destination.id
 
       json.image destination.get_destination_image


### PR DESCRIPTION
- itinerary show ページ：住所登録がない場合は、東京駅を表示するように条件文をjavascriptファイルに記述。
- itinerary show アクション：不要なコード削除