### PR TITLE
style:itinerary index　ブックマークとブックマーク数の位置微調整

### DIFF
--- a/app/views/public/itineraries/_index.html.erb
+++ b/app/views/public/itineraries/_index.html.erb
@@ -48,7 +48,7 @@
         </div>
         
 
-        <div class ="d-flex justify-content-end">
+        <div class ="d-flex justify-content-end align-items-center ">
           <i class="fa-regular fa-bookmark mr-1"></i><%= itinerary.bookmarks.count %>
         </div>
 


### PR DESCRIPTION
itinerary index　ブックマークとブックマーク数の位置微調整
縦方向にずれがあったため微調整し、ラインを揃えた。