### PR TITLE
fit:edit-destination 非同期通信のエラー解決

### DIFF
--- a/app/controllers/public/destinations_controller.rb
+++ b/app/controllers/public/destinations_controller.rb
@@ -33,18 +33,18 @@ class Public::DestinationsController < ApplicationController
     @itinerary = Itinerary.find(params[:itinerary_id])
     @destination = @itinerary.destinations.build(destination_params)
     @destination.itinerary_id = @itinerary.id
-
-
     if @destination.save
+
       @itinerary = Itinerary.find(params[:itinerary_id])
       @previous_status = @itinerary.status
       @destinations = @itinerary.destinations.ordered
       @max_day = @itinerary.day_number
     else
-      #@destinations = @itinerary.destinations.ordered # 全行き先を取得
+      @itinerary = Itinerary.find(params[:itinerary_id])
+      @destinations = @itinerary.destinations.ordered
       @max_day = @itinerary.day_number # 最大日数
       flash.now[:alert] = '行き先の追加に失敗しました。'
-      render :edit_destinations
+      render :error_message
     end
   end
 

--- a/app/models/destination.rb
+++ b/app/models/destination.rb
@@ -35,6 +35,12 @@ class Destination < ApplicationRecord
   private
 
   def day_number_within_itinerary_range
+  
+    if day_number.nil?
+      errors.add(:day_number, "を指定してください")
+      return
+    end
+
     if day_number < 1 || day_number > itinerary.day_number
       errors.add(:day_number, "はしおりの日程内で指定してください")
     end

--- a/app/views/public/destinations/edit_destinations.html.erb
+++ b/app/views/public/destinations/edit_destinations.html.erb
@@ -5,7 +5,7 @@
     </h3>
   </div>
   <!-- エラーメッセージの表示 -->
-  <div class="row">
+  <div id ="error-message" class="row">
     <h3>
       <%= render 'layouts/errormessage', obj: @destination %>
     </h3>

--- a/app/views/public/destinations/error_message.js.erb
+++ b/app/views/public/destinations/error_message.js.erb
@@ -1,0 +1,1 @@
+$("#error-message").html("<%= j(render 'layouts/errormessage', obj: @destination) %>");


### PR DESCRIPTION
edit-destination 非同期通信のエラー解決
新規投稿jフォームを未入力で送信した場合のエラーメッセージを、非同期で表示させるように修正。
day_numberがnillでないかを確かめるコードを追加。